### PR TITLE
chromium: Update to version 95.0.4638.69

### DIFF
--- a/bucket/chromium.json
+++ b/bucket/chromium.json
@@ -1,19 +1,19 @@
 {
     "##": "Check chromium.woolyss.com for different versions of Chromium releases.",
-    "version": "85.0.4183.83",
+    "version": "95.0.4638.69",
     "description": "Browser aiming for safer, faster, and more stable way for all users to experience the web.",
     "homepage": "https://www.chromium.org",
     "license": "BSD-3-Clause",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/macchrome/winchrome/releases/download/v85.0.4183.83-r782793-Win64/ungoogled-chromium-85.0.4183.83-2_Win64.7z",
-            "hash": "sha1:e2a561650ca6f3622acc1d170a6e76ef87405152",
-            "extract_dir": "ungoogled-chromium-85.0.4183.83-2_Win64"
+            "url": "https://github.com/macchrome/winchrome/releases/download/v95.0.4638.69-r920003-Win64/ungoogled-chromium-95.0.4638.69-1_Win64.7z",
+            "hash": "sha1:3b53df41a046f9e49282f9435383ab525bb94014",
+            "extract_dir": "ungoogled-chromium-95.0.4638.69-1_Win64"
         },
         "32bit": {
-            "url": "https://github.com/macchrome/winchrome/releases/download/v85.0.4183.83-r782793-Win64/Ungoogled-Chromium-85.0.4183.83-2_Win32.7z",
-            "hash": "sha1:7be72395b89ce0cc5f6fdbcd3a90835baf4051e8",
-            "extract_dir": "Ungoogled-Chromium-85.0.4183.83-2_Win32"
+            "url": "https://github.com/macchrome/winchrome/releases/download/v95.0.4638.69-r920003-Win64/ungoogled-chromium-95.0.4638.69-1_Win32.7z",
+            "hash": "sha1:4dd46ef98801be4d02a03d00220ff4902082daf2",
+            "extract_dir": "ungoogled-chromium-95.0.4638.69-1_Win32"
         }
     },
     "bin": [


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->

<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
-->
Update [chromium](https://github.com/macchrome/winchrome/releases/) version 85.0.4183.83 to 95.0.4638.69.
<!-- or -->

<!--
  If this is a manifest for a new package, make sure that you follow the general order of
  fields as shown below:
  `version`
  `description`
  `homepage`
  `license`
  `url`
  `hash`
  `pre_install`
  `installer`
  `post_install`
  `uninstaller`
  `bin`
  `shortcuts`
  `persist`
  `checkver`
  `autoupdate`
  `notes`
-->
